### PR TITLE
Allow setting list of pins to sample after construction

### DIFF
--- a/src/AdvancedADC.h
+++ b/src/AdvancedADC.h
@@ -48,7 +48,7 @@ class AdvancedADC {
         SampleBuffer read();
         int begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers);
         int begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers, size_t n_pins, pin_size_t *pins) {
-            static_assert(n_pins < AN_MAX_ADC_CHANNELS, "A maximum of 5 channels can be sampled successively.");
+            if (n_pins > AN_MAX_ADC_CHANNELS) n_pins = AN_MAX_ADC_CHANNELS;
             for (size_t i = 0; i < n_pins; ++i) {
                 adc_pins[i] = analogPinToPinName(pins[i]);
             }

--- a/src/AdvancedADC.h
+++ b/src/AdvancedADC.h
@@ -42,10 +42,18 @@ class AdvancedADC {
                 adc_pins[n_channels++] = analogPinToPinName(p);
             }
         }
+        AdvancedADC(): n_channels(0), descr(nullptr) {}
         ~AdvancedADC();
         bool available();
         SampleBuffer read();
         int begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers);
+        int begin(uint32_t resolution, uint32_t sample_rate, size_t n_samples, size_t n_buffers, size_t n_pins, pin_size_t *pins) {
+            static_assert(n_pins < AN_MAX_ADC_CHANNELS, "A maximum of 5 channels can be sampled successively.");
+            for (size_t i = 0; i < n_pins; ++i) {
+                adc_pins[i] = analogPinToPinName(pins[i]);
+            }
+            n_channels = n_pins;
+        }
         int stop();
 };
 


### PR DESCRIPTION
Arguably, in user code, the list of pins to sample will typically be known and fixed at compile-time.

However, when wrapping this into a library (Mozzi; for the purpose of providing a cross-platform analog read mechanism), it will be very helpful to have a way to adjust the pins to sample after construction.